### PR TITLE
Too slow training problem on TPU

### DIFF
--- a/scripts/train.py
+++ b/scripts/train.py
@@ -94,7 +94,7 @@ if __name__ == "__main__":
         dataset = (
             get_dataset(dataset_files, tokenizer, args.auto_encoding)
             if not args.use_tfrecord
-            else get_tfrecord_dataset(dataset_files, args.max_sequence_length)
+            else get_tfrecord_dataset(dataset_files, args.max_sequence_length if args.device.upper() == "TPU" else None)
         )
         dataset = dataset.shuffle(args.shuffle_buffer_size).unbatch()
         train_dataset = (

--- a/seq2seq/data.py
+++ b/seq2seq/data.py
@@ -34,7 +34,7 @@ def get_dataset(dataset_file_path: str, tokenizer: text.SentencepieceTokenizer, 
     return dataset.map(tokenize_fn).map(make_train_examples)
 
 
-def get_tfrecord_dataset(dataset_file_path: str) -> tf.data.Dataset:
+def get_tfrecord_dataset(dataset_file_path: str, max_sequence_length: int) -> tf.data.Dataset:
     """ Read TFRecord dataset file and construct tensorflow dataset """
     dataset = tf.data.TFRecordDataset(dataset_file_path)
 
@@ -47,8 +47,14 @@ def get_tfrecord_dataset(dataset_file_path: str) -> tf.data.Dataset:
     def _parse_fn(example_proto):
         """ Parse the input `tf.train.Example` proto using the dictionary above. """
         parsed_example = tf.io.parse_single_example(example_proto, feature_description)
-        source_tokens = tf.cast(parsed_example["source"].values, tf.int32)
-        target_tokens = tf.cast(parsed_example["target"].values, tf.int32)
+        source_tokens = tf.cast(parsed_example["source"].values, tf.int32)[:max_sequence_length]
+        target_tokens = tf.cast(parsed_example["target"].values, tf.int32)[:max_sequence_length]
+        source_tokens = tf.concat(
+            [source_tokens, tf.zeros([max_sequence_length - tf.shape(source_tokens)[0]], tf.int32)], axis=0
+        )
+        target_tokens = tf.concat(
+            [target_tokens, tf.zeros([max_sequence_length - tf.shape(target_tokens)[0]], tf.int32)], axis=0
+        )
         return source_tokens, target_tokens
 
     return dataset.map(_parse_fn).map(make_train_examples)

--- a/seq2seq/data.py
+++ b/seq2seq/data.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import List, Optional
 
 import tensorflow as tf
 import tensorflow_text as text
@@ -34,7 +34,7 @@ def get_dataset(dataset_file_path: str, tokenizer: text.SentencepieceTokenizer, 
     return dataset.map(tokenize_fn).map(make_train_examples)
 
 
-def get_tfrecord_dataset(dataset_file_path: str, max_sequence_length: int) -> tf.data.Dataset:
+def get_tfrecord_dataset(dataset_file_path: str, max_sequence_length: Optional[int] = None) -> tf.data.Dataset:
     """ Read TFRecord dataset file and construct tensorflow dataset """
     dataset = tf.data.TFRecordDataset(dataset_file_path)
 
@@ -49,12 +49,14 @@ def get_tfrecord_dataset(dataset_file_path: str, max_sequence_length: int) -> tf
         parsed_example = tf.io.parse_single_example(example_proto, feature_description)
         source_tokens = tf.cast(parsed_example["source"].values, tf.int32)[:max_sequence_length]
         target_tokens = tf.cast(parsed_example["target"].values, tf.int32)[:max_sequence_length]
-        source_tokens = tf.concat(
-            [source_tokens, tf.zeros([max_sequence_length - tf.shape(source_tokens)[0]], tf.int32)], axis=0
-        )
-        target_tokens = tf.concat(
-            [target_tokens, tf.zeros([max_sequence_length - tf.shape(target_tokens)[0]], tf.int32)], axis=0
-        )
+
+        if max_sequence_length is not None:
+            source_tokens = tf.concat(
+                [source_tokens, tf.zeros([max_sequence_length - tf.shape(source_tokens)[0]], tf.int32)], axis=0
+            )
+            target_tokens = tf.concat(
+                [target_tokens, tf.zeros([max_sequence_length - tf.shape(target_tokens)[0]], tf.int32)], axis=0
+            )
         return source_tokens, target_tokens
 
     return dataset.map(_parse_fn).map(make_train_examples)

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -33,11 +33,11 @@ def test_get_dataset(data_path):
 
 
 def test_get_tfrecord_dataset(data_path):
-    tfrecord_dataset = get_tfrecord_dataset(os.path.join(data_path, "sample_dataset.tfrecord"))
+    tfrecord_dataset = get_tfrecord_dataset(os.path.join(data_path, "sample_dataset.tfrecord"), 10)
     assert len(list(tfrecord_dataset)) == 8
 
     data = next(iter(tfrecord_dataset))
     (encoder_input, decoder_input), labels = data
-    tf.debugging.assert_equal(tf.shape(encoder_input), [12, 13])
-    tf.debugging.assert_equal(tf.shape(decoder_input), [12, 13])
-    tf.debugging.assert_equal(tf.shape(labels), [12])
+    tf.debugging.assert_equal(tf.shape(encoder_input), [9, 10])
+    tf.debugging.assert_equal(tf.shape(decoder_input), [9, 10])
+    tf.debugging.assert_equal(tf.shape(labels), [9])


### PR DESCRIPTION
#5 
Training speed was so slow on TPU. I found the problem is shpae of model input is difference for every step because sequence length is difference for each example [Refer](https://cloud.google.com/tpu/docs/tpus#shapes). So, When using TFRecordDataset on TPU, automatically fit tensor shapes based on max sequence length.
